### PR TITLE
fix: steps coloring based on step state

### DIFF
--- a/client/src/components/Steps/index.js
+++ b/client/src/components/Steps/index.js
@@ -54,7 +54,8 @@ const Card = forwardRef(
     ref
   ) => {
     const bgColor = `${variant}Light`;
-    const borderColor = `${variant}Mid`;
+    const borderColor =
+      variant === 'neutral' ? `${variant}Light` : `${variant}Mid`;
     const circleColor =
       variant === 'neutral' ? `${variant}Mid` : `${variant}Main`;
 

--- a/client/src/components/Steps/style.js
+++ b/client/src/components/Steps/style.js
@@ -78,7 +78,7 @@ export const Circle = styled.div`
   position: absolute;
   border-radius: 50%;
   border: ${({ theme, borderColor }) =>
-    `5px solid ${theme.colors[borderColor]}`};
+    `7px solid ${theme.colors[borderColor]}`};
   right: ${({ direction }) => (direction === 'right' ? '0' : null)};
   left: ${({ direction }) => (direction === 'left' ? '0' : null)};
   top: -18px;

--- a/client/src/pages/Home/index.js
+++ b/client/src/pages/Home/index.js
@@ -45,7 +45,7 @@ const Home = () => {
   const completedClaim = currentStep?.stage === 'afterClaiming';
 
   const getStepStatus = (step, i) => {
-    const isCurrentStep = currentStep && step.name === currentStep.name;
+    const isCurrentStep = currentStep && step.id === currentStep.id;
     const variant = step.isCompleted
       ? 'neutral'
       : isCurrentStep

--- a/server/database/build-tables.js
+++ b/server/database/build-tables.js
@@ -7,9 +7,9 @@ const buildTables = async () => {
   await init.createAutoTimestamps();
   await init.buildMigrations();
 
-  await models.users.createTable();
   await models.media.createTable();
   await models.organisations.createTable();
+  await models.users.createTable();
   await models.landingPageContent.createTable();
   await models.steps.createTable();
   await models.contentAuditLog.createTable();

--- a/server/database/dummy-data-prod/steps-content.js
+++ b/server/database/dummy-data-prod/steps-content.js
@@ -134,7 +134,7 @@ const addStepContent = async () => {
     stage: T.stageTypes.CLAIMING,
     stepOrder: 2,
     title: `Create account`,
-    description: `Create an account on the Government website if you haven’t already. You’ll want to do this as soon as possible!`,
+    description: `Create an account on the Government website. You’ll want to do this as soon as possible!`,
     pageTitle: ``,
     pageDescription: ``,
     howLongDoesItTake: { timeRangeText: `5 to 10 minutes` },


### PR DESCRIPTION
Closes #128 

### Description
Steps weren't being colored as they should be, based on their state of completed, active or not started

### What did I do?
- [x] Use the step id to check for the current step instead of the name
> it was not picking the current step correctly everytime
- [x] Edited the step border to match the designs
- [x] Edited create account step description to match the designs
- [x] Updated the DB build script to create organisations & media tables before users
> it was throwing an error when building the DB using the command `npm run build:db


### Screenshot
Showing the steps colors based on state where the first two are completed, the third is in active and last not started

![2021-08-29 (2)](https://user-images.githubusercontent.com/44949822/131263598-4d4218df-8d88-4239-89e6-dc6371f6d014.png)
