### PR TITLE
Fix phone number direction

### DIFF
--- a/client/src/components/HelpButton/index.js
+++ b/client/src/components/HelpButton/index.js
@@ -104,6 +104,7 @@ const HelpButton = ({
                   color="secondaryMain"
                   isSmall
                   to={formatLink('PHONE', { phoneNumber: '02071231234' }).link}
+                  dir={'ltr'}
                 >
                   {t(
                     'common.section.helpMe.govPhone',

--- a/client/src/components/HelpButton/index.js
+++ b/client/src/components/HelpButton/index.js
@@ -103,7 +103,7 @@ const HelpButton = ({
                   weight="bold"
                   color="secondaryMain"
                   isSmall
-                  to={formatLink('PHONE', { phoneNumber: '02071231234' }).link}
+                  to={formatLink('PHONE', { phoneNumber: '08003285644' }).link}
                   dir={'ltr'}
                 >
                   {t(

--- a/client/src/pages/Step/index.js
+++ b/client/src/pages/Step/index.js
@@ -285,6 +285,7 @@ const Step = () => {
                   )}
                   target="_blank"
                   rel="noopener noreferrer"
+                  dir={step.whereDoYouNeedToGo.type === 'PHONE' ? 'ltr' : null}
                   external
                 />
               </Col>

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -51,7 +51,9 @@ if (config.common.env === PRODUCTION) {
   );
 
   app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '..', '..', 'client', 'build', 'index.html'));
+    res.sendFile(
+      path.join(__dirname, '..', '..', 'client', 'build', 'index.html'),
+    );
   });
 }
 

--- a/server/src/services/translation/translate-steps.js
+++ b/server/src/services/translation/translate-steps.js
@@ -51,7 +51,12 @@ const translateSteps = async ({ lng, steps }) => {
         pageTitle: res.content.pageTitle,
         pageDescription: res.content.pageDescription,
         howLongDoesItTake: res.content.howLongDoesItTake,
-        whereDoYouNeedToGo: res.content.whereDoYouNeedToGo,
+        whereDoYouNeedToGo: whereDoYouNeedToGo
+          ? {
+              ...res.content.whereDoYouNeedToGo,
+              type: whereDoYouNeedToGo && whereDoYouNeedToGo.type,
+            }
+          : null,
         thingsYouWillNeed: Object.values(res.content.thingsYouWillNeed),
         whatYouWillNeedToKnow: Object.values(res.content.whatYouWillNeedToKnow),
         topTip: res.content.topTip,


### PR DESCRIPTION
Fix for telephone numbers flipping when selecting a right-to-left language such as Arabic.

Phone numbers are in two locations:
1 - Help me menu on right hand side of screen (pop up)
2 - https://hyde-dev.herokuapp.com/hyde/steps/5

Both should be the correct way around, 0800 328 5644

Closes https://github.com/yalla-coop/cost-of-living-support/issues/223#issuecomment-1385302860

