### PR TITLE
translate steps partially

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -43,9 +43,9 @@ function App() {
       <Global styles={globalStyle} />
       <ThemeProvider theme={theme}>
         <AccessibilityProvider>
-          <StepsProvider>
-            <AuthProvider>
-              <Router basename={process.env.PUBLIC_URL}>
+          <AuthProvider>
+            <Router basename={process.env.PUBLIC_URL}>
+              <StepsProvider>
                 <ScrollToTop />
                 <Routes>
                   <Route
@@ -158,9 +158,9 @@ function App() {
                     </Route>
                   </Route>
                 </Routes>
-              </Router>
-            </AuthProvider>
-          </StepsProvider>
+              </StepsProvider>
+            </Router>
+          </AuthProvider>
         </AccessibilityProvider>
         <CookieBot domainGroupId={domainGroupId} />
       </ThemeProvider>

--- a/client/src/api-calls/steps.js
+++ b/client/src/api-calls/steps.js
@@ -12,9 +12,11 @@ const editStep = async ({ id, form, options } = {}) => {
     return { error: err };
   }
 };
-const getStepById = async (id, { options } = {}) => {
+const getStepById = async ({ id, lng, forPublic, options = {} } = {}) => {
   try {
-    const { data } = await axios.get(`${STEPS_BASE}/${id}`);
+    const { data } = await axios.get(`${STEPS_BASE}/${id}`, {
+      params: { lng, forPublic },
+    });
     return { data };
   } catch (error) {
     const err = handleError(error, options);

--- a/client/src/context/steps.js
+++ b/client/src/context/steps.js
@@ -1,4 +1,5 @@
 import { createContext, useState, useContext, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useLanguage } from '../helpers';
@@ -86,12 +87,17 @@ const StepsProvider = ({ children, ...props }) => {
   const [justCompletedId, setJustCompletedId] = useState('');
   const [loadingSteps, setLoadingSteps] = useState(false);
   const [stepsError, setStepsError] = useState('');
+  const location = useLocation();
+
+  const adminPages = location?.pathname?.includes('/admin/');
 
   useEffect(() => {
     let mounted = true;
     async function fetchData() {
       setLoadingSteps(true);
-      const { data: newSteps, error } = await Steps.getStepsContent({ lng });
+      const { data: newSteps, error } = await Steps.getStepsContent({
+        lng: adminPages ? 'en' : lng,
+      });
       if (mounted) {
         let updatedSteps = [];
         if (error) {
@@ -115,7 +121,7 @@ const StepsProvider = ({ children, ...props }) => {
     return () => {
       mounted = false;
     };
-  }, [lng]);
+  }, [lng, adminPages]);
 
   useEffect(() => {
     const updatedSteps = steps.map((step) => {

--- a/client/src/pages/Admin/StepForm/index.js
+++ b/client/src/pages/Admin/StepForm/index.js
@@ -75,7 +75,11 @@ const StepForm = () => {
   useEffect(() => {
     const getStepData = async () => {
       setState({ loading: true });
-      const { error, data } = await Steps.getStepById(stepId);
+      const { error, data } = await Steps.getStepById({
+        id: stepId,
+        lng: 'en',
+        forPublic: false,
+      });
 
       setState({ loading: false });
       if (error) {

--- a/client/src/pages/Home/LandingContent.js
+++ b/client/src/pages/Home/LandingContent.js
@@ -37,7 +37,7 @@ const LandingContent = ({ uniqueSlug }) => {
   useEffect(() => {
     let mounted = true;
     async function fetchData() {
-      const hideMessage = message.loading('Loading...');
+      const hideMessage = message.loading('Loading...', 0);
       const { data, error } = await LandingPage.getLandingPageContent({
         lng,
         forPublic: true,

--- a/server/src/database/init/migrations.sql
+++ b/server/src/database/init/migrations.sql
@@ -12,4 +12,5 @@ INSERT INTO "migrations" ("name") VALUES
   ('/20221124140906-remove-backup-email-unique-constraint'),
   ('/20221201042815-add-deleted-status-for-organisations'),
   ('/20221214090033-add-languages-tables'),
-  ('/20221214173721-convert-json-to-jsonb');
+  ('/20221214173721-convert-json-to-jsonb'),
+  ('/20230125051040-add-all-fields-translated-to-steps-i18n');

--- a/server/src/database/migrations/20230125051040-add-all-fields-translated-to-steps-i18n.js
+++ b/server/src/database/migrations/20230125051040-add-all-fields-translated-to-steps-i18n.js
@@ -1,0 +1,58 @@
+let dbm;
+let type;
+let seed;
+const fs = require('fs');
+const path = require('path');
+
+let Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  const filePath = path.join(
+    __dirname,
+    'sqls',
+    '20230125051040-add-all-fields-translated-to-steps-i18n-up.sql',
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err);
+      console.log(`received data: ${data}`);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  const filePath = path.join(
+    __dirname,
+    'sqls',
+    '20230125051040-add-all-fields-translated-to-steps-i18n-down.sql',
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err);
+      console.log(`received data: ${data}`);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/server/src/database/migrations/sqls/20230125051040-add-all-fields-translated-to-steps-i18n-down.sql
+++ b/server/src/database/migrations/sqls/20230125051040-add-all-fields-translated-to-steps-i18n-down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE "steps_i18n"
+  DROP COLUMN "all_fields_translated";
+
+COMMIT;

--- a/server/src/database/migrations/sqls/20230125051040-add-all-fields-translated-to-steps-i18n-up.sql
+++ b/server/src/database/migrations/sqls/20230125051040-add-all-fields-translated-to-steps-i18n-up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE "steps_i18n"
+  ADD COLUMN "all_fields_translated" BOOLEAN DEFAULT FALSE;
+
+UPDATE "steps_i18n"
+  SET "all_fields_translated" = TRUE;
+
+COMMIT;

--- a/server/src/database/models/steps-i18n/schema.sql
+++ b/server/src/database/models/steps-i18n/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE "steps_i18n" (
   "what_you_will_need_to_know" JSONB[],
   "top_tip" TEXT,
   "other_tips" TEXT[],
+  "all_fields_translated" BOOLEAN DEFAULT FALSE,
   "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
   "updated_at" TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/server/src/modules/step/controllers/get-step.js
+++ b/server/src/modules/step/controllers/get-step.js
@@ -3,8 +3,12 @@ import * as steps from '../use-cases';
 const getStep = async (req, res, next) => {
   try {
     const { id } = req.params;
-    const { lng } = req.query;
-    const step = await steps.getStep({ id, lng });
+    const { lng, forPublic } = req.query;
+    const step = await steps.getStep({
+      id,
+      lng,
+      forPublic: forPublic === 'true',
+    });
 
     res.json(step);
   } catch (error) {

--- a/server/src/modules/step/model/find.js
+++ b/server/src/modules/step/model/find.js
@@ -8,27 +8,12 @@ const getSteps = async (lng) => {
       s.step_order,
       s.title AS "s_en.title",
       s.description AS "s_en.description",
-      s.page_title AS "s_en.page_title",
-      s.page_description AS "s_en.page_description",
-      s.how_long_does_it_take AS "s_en.how_long_does_it_take",
-      s.where_do_you_need_to_go AS "s_en.where_do_you_need_to_go",
-      s.things_you_will_need AS "s_en.things_you_will_need",
-      s.what_you_will_need_to_know AS "s_en.what_you_will_need_to_know",
-      s.top_tip AS "s_en.top_tip",
-      s.other_tips AS "s_en.other_tips",
 
       s_i18n.title AS "s_i18n.title",
       s_i18n.description AS "s_i18n.description",
-      s_i18n.page_title AS "s_i18n.page_title",
-      s_i18n.page_description AS "s_i18n.page_description",
-      s_i18n.how_long_does_it_take AS "s_i18n.how_long_does_it_take",
-      s_i18n.where_do_you_need_to_go AS "s_i18n.where_do_you_need_to_go",
-      s_i18n.things_you_will_need AS "s_i18n.things_you_will_need",
-      s_i18n.what_you_will_need_to_know AS "s_i18n.what_you_will_need_to_know",
-      s_i18n.top_tip AS "s_i18n.top_tip",
-      s_i18n.other_tips AS "s_i18n.other_tips",
 
       s.is_optional,
+      s_i18n.all_fields_translated,
       s_i18n.language_code
     FROM steps AS s
     LEFT JOIN steps_i18n AS s_i18n
@@ -67,16 +52,19 @@ const getStepById = async (id, lng) => {
       s.top_tip AS "s_en.top_tip",
       s.other_tips AS "s_en.other_tips",
 
-      s_i18n.title AS "s_i18n.title",
-      s_i18n.description AS "s_i18n.description",
-      s_i18n.page_title AS "s_i18n.page_title",
-      s_i18n.page_description AS "s_i18n.page_description",
-      s_i18n.how_long_does_it_take AS "s_i18n.how_long_does_it_take",
-      s_i18n.where_do_you_need_to_go AS "s_i18n.where_do_you_need_to_go",
-      s_i18n.things_you_will_need AS "s_i18n.things_you_will_need",
-      s_i18n.what_you_will_need_to_know AS "s_i18n.what_you_will_need_to_know",
-      s_i18n.top_tip AS "s_i18n.top_tip",
-      s_i18n.other_tips AS "s_i18n.other_tips",
+      COALESCE(s_i18n.title, s.title) AS "s_i18n.title",
+      COALESCE(s_i18n.description, s.description) AS "s_i18n.description",
+      COALESCE(s_i18n.page_title, s.page_title) AS "s_i18n.page_title",
+      COALESCE(s_i18n.page_description, s.page_description) AS "s_i18n.page_description",
+      COALESCE(s_i18n.how_long_does_it_take, s.how_long_does_it_take) AS "s_i18n.how_long_does_it_take",
+      COALESCE(s_i18n.where_do_you_need_to_go, s.where_do_you_need_to_go) AS "s_i18n.where_do_you_need_to_go",
+      COALESCE(s_i18n.things_you_will_need, s.things_you_will_need) AS "s_i18n.things_you_will_need",
+      COALESCE(s_i18n.what_you_will_need_to_know, s.what_you_will_need_to_know) AS "s_i18n.what_you_will_need_to_know",
+      COALESCE(s_i18n.top_tip, s.top_tip) AS "s_i18n.top_tip",
+      COALESCE(s_i18n.other_tips, s.other_tips) AS "s_i18n.other_tips",
+      
+      s_i18n.language_code,
+      s_i18n.all_fields_translated,
       s.is_optional
     FROM steps AS s
     LEFT JOIN steps_i18n AS s_i18n

--- a/server/src/modules/step/use-cases/get-steps.js
+++ b/server/src/modules/step/use-cases/get-steps.js
@@ -11,24 +11,20 @@ const getSteps = async ({ lng }) => {
 
   stepsT.forEach((c) => {
     if (!c.isTranslated) {
-      Translation.createStepI18n({ stepId: c.id, ...c });
+      Translation.createStepI18n({
+        stepId: c.id,
+        title: c.title,
+        description: c.description,
+        languageCode: c.languageCode,
+        allFieldsTranslated: false,
+      });
     }
   });
 
-  const stepsTWithChecklist = stepsT.map((step, index) => {
+  const stepsTWithChecklist = stepsT.map((step) => {
     return {
       ...step,
-      id: index + 1,
-      checklist: [
-        step.thingsYouWillNeed.map((item) => ({
-          ...item,
-          stage: 'thingsYouWillNeed',
-        })),
-        step.whatYouWillNeedToKnow.map((item) => ({
-          ...item,
-          stage: 'whatYouWillNeedToKnow',
-        })),
-      ].flat(),
+      id: step.id,
     };
   });
 

--- a/server/src/modules/translations/model/create.js
+++ b/server/src/modules/translations/model/create.js
@@ -72,6 +72,7 @@ const createStepI18n = async ({
   whatYouWillNeedToKnow,
   topTip,
   otherTips,
+  allFieldsTranslated,
 }) => {
   const sql = `
     INSERT INTO steps_i18n (
@@ -86,7 +87,8 @@ const createStepI18n = async ({
       things_you_will_need,
       what_you_will_need_to_know,
       top_tip,
-      other_tips
+      other_tips,
+      all_fields_translated
     ) VALUES(
       $1,
       $2,
@@ -99,9 +101,21 @@ const createStepI18n = async ({
       $9,
       $10::jsonb[],
       $11,
-      $12
+      $12,
+      $13
     )
-    ON CONFLICT (step_id, language_code) DO NOTHING
+    ON CONFLICT (step_id, language_code) DO UPDATE SET
+      title = COALESCE($3, steps_i18n.title),
+      description = COALESCE($4, steps_i18n.description),
+      page_title = COALESCE($5, steps_i18n.page_title),
+      page_description = COALESCE($6, steps_i18n.page_description),
+      how_long_does_it_take = COALESCE($7, steps_i18n.how_long_does_it_take),
+      where_do_you_need_to_go = COALESCE($8, steps_i18n.where_do_you_need_to_go),
+      things_you_will_need = COALESCE($9, steps_i18n.things_you_will_need),
+      what_you_will_need_to_know = COALESCE($10, steps_i18n.what_you_will_need_to_know),
+      top_tip = COALESCE($11, steps_i18n.top_tip),
+      other_tips = COALESCE($12, steps_i18n.other_tips),
+      all_fields_translated = COALESCE($13, steps_i18n.all_fields_translated)
     RETURNING *
   `;
 
@@ -118,6 +132,7 @@ const createStepI18n = async ({
     whatYouWillNeedToKnow,
     topTip,
     otherTips,
+    allFieldsTranslated,
   ];
 
   const res = await query(sql, values);

--- a/server/src/services/translation/translate-steps.js
+++ b/server/src/services/translation/translate-steps.js
@@ -16,9 +16,10 @@ const translateSteps = async ({ lng, steps }) => {
         topTip,
         otherTips,
         id,
+        allFieldsTranslated,
       } = step;
 
-      if (languageCode === lng || lng === 'en') {
+      if ((languageCode === lng && allFieldsTranslated) || lng === 'en') {
         return {
           ...step,
           languageCode: lng,

--- a/server/src/services/translation/translation-api.js
+++ b/server/src/services/translation/translation-api.js
@@ -30,7 +30,7 @@ const translateText = async ({ text, sourceLang, targetLang }) => {
     const translationData = await translateAWS.translateText(params).promise();
     return translationData.TranslatedText;
   } catch (error) {
-    throw new Error('translateText API error :>> ', error);
+    throw new Error(error);
   }
 };
 

--- a/server/src/services/translation/translation-api.js
+++ b/server/src/services/translation/translation-api.js
@@ -30,7 +30,8 @@ const translateText = async ({ text, sourceLang, targetLang }) => {
     const translationData = await translateAWS.translateText(params).promise();
     return translationData.TranslatedText;
   } catch (error) {
-    throw new Error(error);
+    error.extraData = params;
+    throw error;
   }
 };
 


### PR DESCRIPTION
#### Issues this PR relates to
[#225](https://github.com/yalla-coop/cost-of-living-support/issues/225) 

## Note
when the user goes to the landing page, the page requests all the steps, so we translate all the steps at once, which makes the translation API respond with too many requests errors.
this fix is to change the get steps logic, only to get the title and the description for the steps, so we translate these two fields, and when the user views a single step we translate the whole step. this makes fewer data to be translated at the same time

=======

_NOTE: REMEMBER NOT TO REVIEW UNLESS ALL ACCEPTANCE CRITERIA HAS BEEN TICKED OFF_

---

#### Any info the reviewer needs to know to test 
e.g. Add env vars, run npm install

---

#### Any info the team needs to consider before merged into development
e.g. Will a database need to be rebuilt (and is this ok if existing data), add env vars

---

#### Quick Pull Request Checklist

Please make sure you ensure the following has been done before marking your PR as awaiting-review. 

- Branch is up to date with develop
- Project runs
- You can download and install locally, and run the project locally
- All existing and new features run without bugs
- Checked that features/design works across all agreed browsers + devices
- The new work has been checked with Axe accessibility checker and doesn't throw significant errors  
- Linter is used
- Code is consistent with agreed team style
- Naming of files is consistent with project 
- Tests all pass
- No console logs
